### PR TITLE
Support dotted namespace support for global export alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $ node make-bundle > bundle.js
 
   exports: 'robot',
   // Name to expose on the `window` object
+  // Supports namespacing with dot notation
 
   dependencies: [
     {name: 'lodash', exports: '_'},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umd-wrap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Wrap a block of code into a UMD bundle",
   "main": "index.js",
   "scripts": {

--- a/templates/head.js
+++ b/templates/head.js
@@ -6,7 +6,14 @@
     define([<%= amdDependencies %>], factory);
   }
   else {
-    root[<%= quote %><%= globalAlias %><%= quote %>] = factory(<%= globalDependencies %>);
+    var globalAlias = <%= quote %><%= globalAlias %><%= quote %>;
+    var namespace = globalAlias.split('.');
+    var parent = root;
+    for ( var i = 0; i < namespace.length-1; i++ ) {
+      if ( parent[namespace[i]] === undefined ) parent[namespace[i]] = {};
+      parent = parent[namespace[i]];
+    }
+    parent[namespace[namespace.length-1]] = factory(<%= globalDependencies %>);
   }
 }(this, function(<%= dependencyExports %>) {
   function <%= _requireDep %>(name) {

--- a/test/run.js
+++ b/test/run.js
@@ -62,3 +62,32 @@ test('run bundle', function(t) {
     t.end();
   });
 });
+
+test('with dotted namespace', function(t) {
+  var options = {
+    code: '([1234, _, moment]);',
+    exports: 'p.q.r',
+    dependencies: [
+      {name: 'lodash', exports: '_'},
+      {name: 'moment'}
+    ]
+  };
+
+  var expected = [1234, 'lodash', 'moment'];
+
+  wrap(options, function(err, code) {
+    test('in global environment', function(t) {
+      t.plan(1);
+
+      var a;
+      var sandbox = {_: 'lodash', moment: 'moment'};
+      vm.runInNewContext(code, sandbox);
+      a = sandbox.p.q.r;
+
+      t.deepEqual(a, expected);
+      t.end();
+    });
+
+    t.end();
+  });
+});


### PR DESCRIPTION
Exported global alias should accept dot-notation for namespacing.

The option `exports: 'space.robot'` should be and result in the module being exposed to `window.space.robot`, or more specifically `window['space']['robot']`, instead of `window['space.robot']` which is the current behavior.

---

I use this package via [cjs-umd](https://github.com/nicolashery/cjs-umd), wanting to convert a library I'm writing to global exports. Due to the organization of said library -- which is composed of many small optional NPM modules which don't pose a problem with `require`s but would be creating quite a mess in the global scope -- I felt the need to export the bundled modules under a namespace.

The only regression caused by allowing dot-notaion for the global export alias that modules which we previously exported with a period in their name would be moved to a nested reference. Since such export names could not be access directly in global scope or via dot notation anyway, and is quite _weird_ to say the least, I find that this regression is justifiable.

I would be very much obliged if this change was merged. And I also request that this package, along with a dependency updated [cjs-umd](https://github.com/nicolashery/cjs-umd) is published onto NPM. I find the latter useful enough to be published alongside umd-wrap!

---

P.S. This is my first pull-request. Forgive me if I'm doing something wrong. For example: should I not have sent the updated `README.md` and `package.json`? If the change is deemed useful I'd refactor any faux-pas noted. :]
